### PR TITLE
Adding support for JSONGraph

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -5,6 +5,7 @@ module.exports = {
       name: '@storybook/addon-essentials',
       options: {
         backgrounds: false,
+        configureJSX: true,
       },
     },
   ],

--- a/src/components/Graph/stories/JSONGraph.stories.tsx
+++ b/src/components/Graph/stories/JSONGraph.stories.tsx
@@ -1,0 +1,31 @@
+import { Meta } from '@storybook/react'
+import React, { useState } from 'react'
+import { Graph } from '..'
+import { ContentModel, GraphModel } from '../../../graph'
+import { largeGraph, smallGraph } from '../../../graph/data/jsonGraphExamples'
+import { Template } from './StoryUtil'
+
+export default {
+  title: 'Examples/JSONGraph',
+  component: Graph,
+  decorators: [
+    (story) => <div style={{ height: '100h', padding: '16px' }}>{story()}</div>,
+  ],
+  parameters: {
+    layout: 'fullscreen',
+  },
+} as Meta
+
+export const SimpleJsonGraph: React.FC = () => {
+  const [model, setModel] = useState(
+    GraphModel.createWithContent(ContentModel.fromJsonGraph(smallGraph))
+  )
+  return <Template model={model} onModelChange={setModel} />
+}
+
+export const RichJsonGraph: React.FC = () => {
+  const [model, setModel] = useState(
+    GraphModel.createWithContent(ContentModel.fromJsonGraph(largeGraph))
+  )
+  return <Template model={model} onModelChange={setModel} />
+}

--- a/src/graph/ContentModel.test.ts
+++ b/src/graph/ContentModel.test.ts
@@ -1,5 +1,7 @@
 import { edge1, node1, node2 } from '../setupTests'
 import { ContentModel } from './ContentModel'
+import { largeGraph, smallGraph } from './data/jsonGraphExamples'
+import { JSONGraph, ModelNode } from './types'
 
 let contentModel: ContentModel
 
@@ -298,5 +300,105 @@ it('Throws creating with missing edge target', () => {
         nodes: { [node1.id]: node1 },
         edges: { [edge1.id]: edge1 },
       }))
+  ).toThrow()
+})
+
+it('Create from json graph spec graph values', () => {
+  contentModel = ContentModel.fromJsonGraph(smallGraph)
+  expect(Object.keys(contentModel.nodes).length).toBe(4)
+  expect(Object.keys(contentModel.edges).length).toBe(2)
+
+  const node = contentModel.getNode('nissan') as ModelNode
+  expect(node?.label).toBe('Nissan')
+
+  const edge = contentModel.getEdgesLinkedToNode(node.id)[0]
+  expect(edge.id).toBeDefined()
+  expect(edge.source).toBe(node.id)
+  expect(edge.target).toBe('infiniti')
+  expect(edge.label).toBe('has_luxury_division')
+  expect(edge.attributes.relation).toBe('has_luxury_division')
+})
+
+it('Create from json graph', () => {
+  contentModel = ContentModel.fromJsonGraph({
+    nodes: {
+      n1: {
+        metadata: { a1: true, a2: 10, a3: 'test', a4: { object: 'example' } },
+      },
+      n2: { label: 'example2' },
+      n3: {},
+    },
+    edges: [
+      { id: 'edge1', source: 'n1', target: 'n2' },
+      { id: 'edge2', source: 'n1', target: 'n3', label: 'test' },
+    ],
+  })
+  expect(Object.keys(contentModel.nodes).length).toBe(3)
+  expect(Object.keys(contentModel.edges).length).toBe(2)
+  expect(contentModel.getNode('n1')).toBeDefined()
+  expect(contentModel.getNode('n1')?.attributes.a1).toBe(true)
+  expect(contentModel.getNode('n1')?.attributes.a2).toBe(10)
+  expect(contentModel.getNode('n1')?.attributes.a3).toBe('test')
+  expect((contentModel.getNode('n1')?.attributes.a4 as any).object).toBe(
+    'example'
+  )
+  expect(contentModel.getNode('n2')).toBeDefined()
+  expect(contentModel.getNode('n3')).toBeDefined()
+  expect(contentModel.getNode('n2')?.label).toBe('example2')
+  expect(contentModel.getEdge('edge1')).toBeDefined()
+  expect(contentModel.getEdge('edge1')?.source).toBe('n1')
+  expect(contentModel.getEdge('edge1')?.target).toBe('n2')
+  expect(contentModel.getEdge('edge2')?.label).toBe('test')
+})
+
+it('Create from json graph spec graph values', () => {
+  contentModel = ContentModel.fromJsonGraph(largeGraph)
+  expect(Object.keys(contentModel.nodes).length).toBe(9)
+  expect(Object.keys(contentModel.edges).length).toBe(8)
+})
+
+it('ContentModel does support single from graphs', () => {
+  contentModel = ContentModel.fromJsonGraph({
+    graphs: [smallGraph.graph as JSONGraph],
+  })
+  expect(Object.keys(contentModel.nodes).length).toBe(4)
+  expect(Object.keys(contentModel.edges).length).toBe(2)
+})
+
+it('Create from json graph spec graph directly', () => {
+  contentModel = ContentModel.fromJsonGraph(largeGraph.graph as JSONGraph)
+  expect(Object.keys(contentModel.nodes).length).toBe(9)
+  expect(Object.keys(contentModel.edges).length).toBe(8)
+})
+
+it('ContentModel does not support empty from graphs', () => {
+  expect(() =>
+    ContentModel.fromJsonGraph({
+      graphs: [],
+    })
+  ).toThrow()
+})
+
+it('ContentModel does not support empty model', () => {
+  expect(() => ContentModel.fromJsonGraph({})).toThrow()
+})
+
+it('ContentModel does not support multiple from graphs', () => {
+  expect(() =>
+    ContentModel.fromJsonGraph({
+      graphs: [smallGraph.graph as JSONGraph, largeGraph.graph as JSONGraph],
+    })
+  ).toThrow()
+})
+
+it('ContentModel does not support hyperedges from graphs', () => {
+  const hyperGraph = ({
+    nodes: smallGraph.graph?.nodes,
+    hyperedges: smallGraph.graph?.edges,
+  } as unknown) as JSONGraph
+  expect(() =>
+    ContentModel.fromJsonGraph({
+      graph: hyperGraph,
+    })
   ).toThrow()
 })

--- a/src/graph/ContentModel.ts
+++ b/src/graph/ContentModel.ts
@@ -3,6 +3,9 @@ import {
   ModelEdge,
   ModelGraphData,
   ModelAttributeSet,
+  JSONGraphData,
+  JSONGraph,
+  JSONGraphNode,
 } from './types'
 import { v4 } from 'uuid'
 
@@ -16,6 +19,57 @@ export class ContentModel {
       (acc, edge) => acc.addEdge(edge),
       model
     )
+    return model
+  }
+
+  public static fromJsonGraph(data: JSONGraphData | JSONGraph): ContentModel {
+    let graphData: JSONGraph
+    if ('nodes' in data) {
+      graphData = data
+    } else {
+      if (data.graph !== undefined) {
+        graphData = data.graph
+      } else if (data.graphs?.length === 1) {
+        graphData = data.graphs[0]
+      } else {
+        throw new Error(`Only a single graph is supported`)
+      }
+    }
+    if ('hyperedges' in graphData) {
+      throw new Error(`Hyper edges are not supported`)
+    }
+
+    let model = Object.entries(graphData.nodes).reduce((acc, entry) => {
+      const node: ModelNode = { id: entry[0], attributes: {} }
+      const jsonNode: JSONGraphNode = entry[1]
+      if (jsonNode.label !== undefined) {
+        node.label = jsonNode.label
+      }
+      if (jsonNode.metadata !== undefined) {
+        node.attributes = jsonNode.metadata
+      }
+      return acc.addNode(node)
+    }, ContentModel.createEmpty())
+    model = Object.values(graphData.edges).reduce((acc, jsonEdge) => {
+      const edge: Omit<ModelEdge, 'id'> & { id?: string } = {
+        source: jsonEdge.source,
+        target: jsonEdge.target,
+        attributes: {},
+      }
+      if (jsonEdge.id !== undefined) {
+        edge.id = jsonEdge.id
+      }
+      if (jsonEdge.label !== undefined || jsonEdge.relation !== undefined) {
+        edge.label = jsonEdge.label ?? jsonEdge.relation
+      }
+      if (jsonEdge.metadata !== undefined) {
+        edge.attributes = jsonEdge.metadata
+      }
+      if (jsonEdge.relation !== undefined) {
+        edge.attributes.relation = jsonEdge.relation
+      }
+      return acc.addEdge(edge)
+    }, model)
     return model
   }
 

--- a/src/graph/data/jsonGraphExamples.ts
+++ b/src/graph/data/jsonGraphExamples.ts
@@ -1,0 +1,561 @@
+/* eslint-disable @typescript-eslint/camelcase */
+// Copyright 2014 Anthony Bargnesi, Anselmo DiFabio, William Hayes
+// https://github.com/jsongraph/jsongraph.rb
+
+import { JSONGraphData } from '../types'
+
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+// Graphs from JSON Graph Spec to ensure compatibility
+
+export const smallGraph = {
+  graph: {
+    id: 'car-manufacturer-relationships',
+    type: 'car',
+    label: 'Car Manufacturer Relationships',
+    nodes: {
+      nissan: {
+        label: 'Nissan',
+      },
+      infiniti: {
+        label: 'Infiniti',
+      },
+      toyota: {
+        label: 'Toyota',
+      },
+      lexus: {
+        label: 'Lexus',
+      },
+    },
+    edges: [
+      {
+        source: 'nissan',
+        target: 'infiniti',
+        relation: 'has_luxury_division',
+      },
+      {
+        source: 'toyota',
+        target: 'lexus',
+        relation: 'has_luxury_division',
+      },
+    ],
+  },
+} as JSONGraphData
+
+export const largeGraph = {
+  graph: {
+    nodes: {
+      'p(HGNC:LTA)': {
+        metadata: {
+          yloc: 105,
+          xloc: 265,
+        },
+        label: 'p(HGNC:LTA)',
+      },
+      'r(HGNC:IFNG)': {
+        metadata: {
+          yloc: 30,
+          xloc: 45,
+        },
+        label: 'r(HGNC:IFNG)',
+      },
+      'bp(GO:"T-helper 1 type immune response")': {
+        metadata: {
+          yloc: 230,
+          xloc: 165,
+        },
+        label: 'bp(GO:"T-helper 1 type immune response")',
+      },
+      'r(HGNC:LTA)': {
+        metadata: {
+          yloc: 30,
+          xloc: 265,
+        },
+        label: 'r(HGNC:LTA)',
+      },
+      'r(HGNC:IL2)': {
+        metadata: {
+          yloc: 30,
+          xloc: 155,
+        },
+        label: 'r(HGNC:IL2)',
+      },
+      'r(HGNC:LTB)': {
+        metadata: {
+          yloc: 30,
+          xloc: 375,
+        },
+        label: 'r(HGNC:LTB)',
+      },
+      'p(HGNC:IFNG)': {
+        metadata: {
+          yloc: 105,
+          xloc: 45,
+        },
+        label: 'p(HGNC:IFNG)',
+      },
+      'p(HGNC:IL2)': {
+        metadata: {
+          yloc: 105,
+          xloc: 155,
+        },
+        label: 'p(HGNC:IL2)',
+      },
+      'p(HGNC:LTB)': {
+        metadata: {
+          yloc: 105,
+          xloc: 375,
+        },
+        label: 'p(HGNC:LTB)',
+      },
+    },
+    edges: [
+      {
+        source: 'r(HGNC:IL2)',
+        relation: 'translatedTo',
+        target: 'p(HGNC:IL2)',
+        metadata: {
+          evidences: [
+            {
+              bel_statement: 'r(HGNC:IL2) translatedTo p(HGNC:IL2)',
+              citation: {
+                type: 'Online Resource',
+                id: 'http://www.ncbi.nlm.nih.gov/gene/',
+                name: 'NCBI Entrez Gene',
+              },
+              experiment_context: {
+                SpeciesName: 'Mouse',
+                Species: '10090',
+              },
+            },
+            {
+              bel_statement: 'r(HGNC:IL2) translatedTo p(HGNC:IL2)',
+              citation: {
+                type: 'Online Resource',
+                id: 'http://www.ncbi.nlm.nih.gov/gene/',
+                name: 'NCBI Entrez Gene',
+              },
+              experiment_context: {
+                SpeciesName: 'Human',
+                Species: '9606',
+              },
+            },
+            {
+              bel_statement: 'r(HGNC:IL2) translatedTo p(HGNC:IL2)',
+              citation: {
+                type: 'Online Resource',
+                id: 'http://www.ncbi.nlm.nih.gov/gene/',
+                name: 'NCBI Entrez Gene',
+              },
+              experiment_context: {
+                SpeciesName: 'Rat',
+                Species: '10116',
+              },
+            },
+          ],
+        },
+      },
+      {
+        source: 'p(HGNC:LTA)',
+        relation: 'increases',
+        target: 'bp(GO:"T-helper 1 type immune response")',
+        metadata: {
+          evidences: [
+            {
+              bel_statement:
+                'p(HGNC:LTA) increases bp(GO:"T-helper 1 type immune response")',
+              citation: {
+                type: 'PubMed',
+                id: '15745050',
+                name: 'Acta Virol 2004 48(4) 263-6',
+              },
+              summary_text:
+                'IM shows a mainly Th1-type profile, so Th1-type cytokines such as interleukin-2 (IL-2), interferon-gamma (IFN-gamma), and lymphotoxin (LT) are moderately enhanced. ',
+              experiment_context: {
+                Cell: 'Th1 cell',
+                SpeciesName: 'Human',
+                Species: '9606',
+              },
+              metadata: {
+                reviewer: 'dpncab',
+              },
+            },
+          ],
+        },
+      },
+      {
+        source: 'p(HGNC:IFNG)',
+        relation: 'increases',
+        target: 'bp(GO:"T-helper 1 type immune response")',
+        metadata: {
+          evidences: [
+            {
+              bel_statement:
+                'p(HGNC:IFNG) increases bp(GO:"T-helper 1 type immune response")',
+              citation: {
+                type: 'PubMed',
+                id: '15745050',
+                name: 'Acta Virol 2004 48(4) 263-6',
+              },
+              experiment_context: {
+                Cell: 'Th1 cell',
+                SpeciesName: 'Human',
+                Species: '9606',
+              },
+              summary_text:
+                'IM shows a mainly Th1-type profile, so Th1-type cytokines such as interleukin-2 (IL-2), interferon-gamma (IFN-gamma), and lymphotoxin (LT) are moderately enhanced. ',
+            },
+            {
+              bel_statement:
+                'p(HGNC:IFNG) increases bp(GO:"T-helper 1 type immune response")',
+              citation: {
+                type: 'PubMed',
+                id: '11739273',
+                name: 'Circ Res 2001 Dec 7 89(12) 1092-103',
+              },
+              experiment_context: {
+                Cell: 'Endothelial Cells',
+                SpeciesName: 'Human',
+                Species: '9606',
+              },
+              summary_text:
+                'IL-12p40, dimerized with the IL-12p35 subunit, triggers synthesis of IFN-, a cytokine that not only directly promotes Th1 responses, but further elevates CD40 levels',
+            },
+            {
+              bel_statement:
+                'p(HGNC:IFNG) increases bp(GO:"T-helper 1 type immune response")',
+              citation: {
+                type: 'PubMed',
+                id: '10756059',
+                name: 'J Virol 2000 May 74(9) 4429-32',
+              },
+              experiment_context: {
+                Cell: 'Th1 cell',
+                SpeciesName: 'Mouse',
+                Species: '10090',
+              },
+              summary_text:
+                'Analysis of C57BL/6 mice acutely infected with lymphocytic choriomeningitis virus (LCMV) by using intracellular cytokine staining revealed a high frequency (2 to 10%) of CD4(+) T cells secreting the Th1-associated cytokines interleukin-2 (IL-2), gamma interferon (IFN-gamma), and tumor necrosis factor alpha, with no concomitant increase in the frequency of CD4(+) T cells secreting the Th2-associated cytokines IL-4, IL-5, and IL-10 following stimulation with viral peptides.',
+            },
+            {
+              bel_statement:
+                'p(HGNC:IFNG) increases bp(GO:"T-helper 1 type immune response")',
+              citation: {
+                type: 'PubMed',
+                id: '10077627',
+                name: 'Proc Natl Acad Sci U S A 1999 Mar 16 96(6) 3006-11',
+              },
+              experiment_context: {
+                Cell: 'Th1 cell',
+                SpeciesName: 'Mouse',
+                Species: '10090',
+              },
+              summary_text:
+                'CyCAP is a widely expressed secreted glycoprotein that modulates the host response to endotoxin gene-targeted CyCAP-deficient mice are more sensitive to the lethal effects of endotoxin in response to endotoxin, CyCAP-deficient mice overproduce interleukin 12 and interferon-gamma systemically and tumor necrosis factor alpha locally, these are proinflammatory molecules that also promote T helper 1 responses',
+            },
+            {
+              bel_statement:
+                'p(HGNC:IFNG) increases bp(GO:"T-helper 1 type immune response")',
+              citation: {
+                type: 'PubMed',
+                id: '11057672',
+                name: 'Nature 2000 Oct 19 407(6806) 916-20',
+              },
+              experiment_context: {
+                Cell: 'Th1 cell',
+                SpeciesName: 'Human',
+                Species: '9606',
+              },
+              summary_text:
+                'Th1 cells produce interleukin (IL)-2, interferon-gamma (IFN-gamma) and lymphotoxin-beta, which mediate pro-inflammatory functions critical for the development of cell-mediated immune responses, whereas Th2 cells secrete cytokines such as IL-4, IL-5 and IL-10 that enhance humoral immunity.',
+            },
+            {
+              bel_statement:
+                'p(HGNC:IFNG) increases bp(GO:"T-helper 1 type immune response")',
+              citation: {
+                type: 'PubMed',
+                id: '11397944',
+                name: 'Science 2001 Jun 8 292(5523) 1907-10',
+              },
+              experiment_context: {
+                Cell: 'Th1 cell',
+                SpeciesName: 'Human',
+                Species: '9606',
+              },
+              summary_text:
+                'TH1 cells express IFN-g and mediate cellular immunity. TH2 cells express IL-4, IL-5, and IL-13 and mediate nonphagocytic immunity.',
+            },
+          ],
+        },
+      },
+      {
+        source: 'p(HGNC:IL2)',
+        relation: 'increases',
+        target: 'bp(GO:"T-helper 1 type immune response")',
+        metadata: {
+          evidences: [
+            {
+              bel_statement:
+                'p(HGNC:IL2) increases bp(GO:"T-helper 1 type immune response")',
+              citation: {
+                type: 'PubMed',
+                id: '15745050',
+                name: 'Acta Virol 2004 48(4) 263-6',
+              },
+              experiment_context: {
+                Cell: 'Th1 cell',
+                SpeciesName: 'Human',
+                Species: '9606',
+              },
+              summary_text:
+                'IM shows a mainly Th1-type profile, so Th1-type cytokines such as interleukin-2 (IL-2), interferon-gamma (IFN-gamma), and lymphotoxin (LT) are moderately enhanced. ',
+            },
+            {
+              bel_statement:
+                'p(HGNC:IL2) increases bp(GO:"T-helper 1 type immune response")',
+              citation: {
+                type: 'PubMed',
+                id: '11057672',
+                name: 'Nature 2000 Oct 19 407(6806) 916-20',
+              },
+              experiment_context: {
+                Cell: 'Th1 cell',
+                SpeciesName: 'Human',
+                Species: '9606',
+              },
+              summary_text:
+                'Th1 cells produce interleukin (IL)-2, interferon-gamma (IFN-gamma) and lymphotoxin-beta, which mediate pro-inflammatory functions critical for the development of cell-mediated immune responses, whereas Th2 cells secrete cytokines such as IL-4, IL-5 and IL-10 that enhance humoral immunity.',
+            },
+            {
+              bel_statement:
+                'p(HGNC:IL2) increases bp(GO:"T-helper 1 type immune response")',
+              citation: {
+                type: 'PubMed',
+                id: '9144387',
+                name: 'Biochem Biophys Res Commun 1997 Apr 7 233(1) 14-9',
+              },
+              experiment_context: {
+                Cell: 'Th1 cell',
+                SpeciesName: 'Human',
+                Species: '9606',
+              },
+              summary_text:
+                'Furthermore, NO inhibits the proliferation of, and production of interleukin-2 (IL-2) and interferon-gamma by, Th1 but not Th2 cells.',
+            },
+            {
+              bel_statement:
+                'p(HGNC:IL2) increases bp(GO:"T-helper 1 type immune response")',
+              citation: {
+                type: 'PubMed',
+                id: '10756059',
+                name: 'J Virol 2000 May 74(9) 4429-32',
+              },
+              experiment_context: {
+                Cell: 'Th1 cell',
+                SpeciesName: 'Mouse',
+                Species: '10090',
+              },
+              summary_text:
+                'Analysis of C57BL/6 mice acutely infected with lymphocytic choriomeningitis virus (LCMV) by using intracellular cytokine staining revealed a high frequency (2 to 10%) of CD4(+) T cells secreting the Th1-associated cytokines interleukin-2 (IL-2), gamma interferon (IFN-gamma), and tumor necrosis factor alpha, with no concomitant increase in the frequency of CD4(+) T cells secreting the Th2-associated cytokines IL-4, IL-5, and IL-10 following stimulation with viral peptides.',
+            },
+          ],
+        },
+      },
+      {
+        source: 'r(HGNC:LTB)',
+        relation: 'translatedTo',
+        target: 'p(HGNC:LTB)',
+        metadata: {
+          evidences: [
+            {
+              bel_statement: 'r(HGNC:LTB) translatedTo p(HGNC:LTB)',
+              citation: {
+                type: 'Online Resource',
+                id: 'http://www.ncbi.nlm.nih.gov/gene/',
+                name: 'NCBI Entrez Gene',
+              },
+              experiment_context: {
+                SpeciesName: 'Rat',
+                Species: '10116',
+              },
+            },
+            {
+              bel_statement: 'r(HGNC:LTB) translatedTo p(HGNC:LTB)',
+              citation: {
+                type: 'Online Resource',
+                id: 'http://www.ncbi.nlm.nih.gov/gene/',
+                name: 'NCBI Entrez Gene',
+              },
+              experiment_context: {
+                SpeciesName: 'Human',
+                Species: '9606',
+              },
+            },
+            {
+              bel_statement: 'r(HGNC:LTB) translatedTo p(HGNC:LTB)',
+              citation: {
+                type: 'Online Resource',
+                id: 'http://www.ncbi.nlm.nih.gov/gene/',
+                name: 'NCBI Entrez Gene',
+              },
+              experiment_context: {
+                SpeciesName: 'Mouse',
+                Species: '10090',
+              },
+            },
+          ],
+        },
+      },
+      {
+        source: 'r(HGNC:IFNG)',
+        relation: 'translatedTo',
+        target: 'p(HGNC:IFNG)',
+        metadata: {
+          evidences: [
+            {
+              bel_statement: 'r(HGNC:IFNG) translatedTo p(HGNC:IFNG)',
+              citation: {
+                type: 'Online Resource',
+                id: 'http://www.ncbi.nlm.nih.gov/gene/',
+                name: 'NCBI Entrez Gene',
+              },
+              experiment_context: {
+                SpeciesName: 'Mouse',
+                Species: '10090',
+              },
+            },
+            {
+              bel_statement: 'r(HGNC:IFNG) translatedTo p(HGNC:IFNG)',
+              citation: {
+                type: 'Online Resource',
+                id: 'http://www.ncbi.nlm.nih.gov/gene/',
+                name: 'NCBI Entrez Gene',
+              },
+              experiment_context: {
+                SpeciesName: 'Human',
+                Species: '9606',
+              },
+            },
+            {
+              bel_statement: 'r(HGNC:IFNG) translatedTo p(HGNC:IFNG)',
+              citation: {
+                type: 'Online Resource',
+                id: 'http://www.ncbi.nlm.nih.gov/gene/',
+                name: 'NCBI Entrez Gene',
+              },
+              experiment_context: {
+                SpeciesName: 'Rat',
+                Species: '10116',
+              },
+            },
+          ],
+        },
+      },
+      {
+        source: 'p(HGNC:LTB)',
+        relation: 'increases',
+        target: 'bp(GO:"T-helper 1 type immune response")',
+        metadata: {
+          evidences: [
+            {
+              bel_statement:
+                'p(HGNC:LTB) increases bp(GO:"T-helper 1 type immune response")',
+              citation: {
+                type: 'PubMed',
+                id: '11057672',
+                name: 'Nature 2000 Oct 19 407(6806) 916-20',
+              },
+              experiment_context: {
+                Cell: 'Th1 cell',
+                SpeciesName: 'Human',
+                Species: '9606',
+              },
+              summary_text:
+                'Th1 cells produce interleukin (IL)-2, interferon-gamma (IFN-gamma) and lymphotoxin-beta, which mediate pro-inflammatory functions critical for the development of cell-mediated immune responses, whereas Th2 cells secrete cytokines such as IL-4, IL-5 and IL-10 that enhance humoral immunity.',
+            },
+          ],
+        },
+      },
+      {
+        source: 'r(HGNC:LTA)',
+        relation: 'translatedTo',
+        target: 'p(HGNC:LTA)',
+        metadata: {
+          evidences: [
+            {
+              bel_statement: 'r(HGNC:LTA) translatedTo p(HGNC:LTA)',
+              citation: {
+                type: 'Online Resource',
+                id: 'http://www.ncbi.nlm.nih.gov/gene/',
+                name: 'NCBI Entrez Gene',
+              },
+              experiment_context: {
+                SpeciesName: 'Human',
+                Species: '9606',
+              },
+            },
+            {
+              bel_statement: 'r(HGNC:LTA) translatedTo p(HGNC:LTA)',
+              citation: {
+                type: 'Online Resource',
+                id: 'http://www.ncbi.nlm.nih.gov/gene/',
+                name: 'NCBI Entrez Gene',
+              },
+              experiment_context: {
+                SpeciesName: 'Mouse',
+                Species: '10090',
+              },
+            },
+            {
+              bel_statement: 'r(HGNC:LTA) translatedTo p(HGNC:LTA)',
+              citation: {
+                type: 'Online Resource',
+                id: 'http://www.ncbi.nlm.nih.gov/gene/',
+                name: 'NCBI Entrez Gene',
+              },
+              experiment_context: {
+                SpeciesName: 'Rat',
+                Species: '10116',
+              },
+            },
+          ],
+        },
+      },
+    ],
+    type: 'BEL-V1.0',
+    metadata: {
+      customer: 'Philip Morris International',
+      speciesName: 'Human',
+      description:
+        'The Th1 response model depicts the causal mechanisms that occur following activation of Th1 cells in response to upstream signals, including IFNG, IL2, LTA, and LTB.',
+      modelVersion: '3.0',
+      graphCreatedByEmail: 'tthomson@genstruct.com',
+      graphCreatedAt: '1305578028000',
+      graphCreatedBy: 'Ty Thomson',
+      graphUpdatedBy: 'Ty Thomson',
+      reference_node: 'bp(GO:"T-helper 1 type immune response")',
+      graphUpdatedByEmail: 'tthomson@genstruct.com',
+      graphProject: 'System Models Project',
+      graphUpdatedAt: '1305578028000',
+      species: 9606,
+      bel_version: '1.0',
+    },
+  },
+} as JSONGraphData

--- a/src/graph/types/index.ts
+++ b/src/graph/types/index.ts
@@ -143,3 +143,32 @@ export interface RefitCommand {
 export interface LayoutCommand {
   type: 'Layout'
 }
+
+/// JSON GRAPH Interfaces - only describes what we need from
+/// https://github.com/jsongraph/json-graph-specification/blob/master/json-graph-schema_v2.json
+/// Note we do not support hyperedges
+
+export interface JSONGraphNode {
+  label?: string
+  metadata?: Record<string, unknown>
+}
+
+export interface JSONGraphEdge {
+  id?: string
+  source: string
+  target: string
+  relation?: string
+  directed?: boolean
+  label?: string
+  metadata?: Record<string, unknown>
+}
+
+export interface JSONGraph {
+  nodes: Record<string, JSONGraphNode>
+  edges: JSONGraphEdge[]
+}
+
+export interface JSONGraphData {
+  graph?: JSONGraph
+  graphs?: JSONGraph[]
+}


### PR DESCRIPTION
Only support single graph.
Does not support hyperedges.
Assumes directed.

Added as an static to content model to create from a json graph.

fixes #15