### PR TITLE
Increase performance of fromJsonGraph

### DIFF
--- a/src/components/Graph/__snapshots__/Graph.test.tsx.snap
+++ b/src/components/Graph/__snapshots__/Graph.test.tsx.snap
@@ -96,27 +96,27 @@ exports[`renders dark 1`] = `
         [
   {
     "id": "e1",
-    "attributes": {},
     "source": "n1",
-    "target": "n2"
+    "target": "n2",
+    "attributes": {}
   },
   {
     "id": "e2",
-    "attributes": {},
     "source": "n1",
-    "target": "n3"
+    "target": "n3",
+    "attributes": {}
   },
   {
     "id": "e3",
-    "attributes": {},
     "source": "n3",
-    "target": "n4"
+    "target": "n4",
+    "attributes": {}
   },
   {
     "id": "e5",
-    "attributes": {},
     "source": "n5",
-    "target": "n5"
+    "target": "n5",
+    "attributes": {}
   }
 ]
       </pre>
@@ -222,27 +222,27 @@ exports[`renders light 1`] = `
         [
   {
     "id": "e1",
-    "attributes": {},
     "source": "n1",
-    "target": "n2"
+    "target": "n2",
+    "attributes": {}
   },
   {
     "id": "e2",
-    "attributes": {},
     "source": "n1",
-    "target": "n3"
+    "target": "n3",
+    "attributes": {}
   },
   {
     "id": "e3",
-    "attributes": {},
     "source": "n3",
-    "target": "n4"
+    "target": "n4",
+    "attributes": {}
   },
   {
     "id": "e5",
-    "attributes": {},
     "source": "n5",
-    "target": "n5"
+    "target": "n5",
+    "attributes": {}
   }
 ]
       </pre>

--- a/src/graph/ContentModel.ts
+++ b/src/graph/ContentModel.ts
@@ -8,14 +8,8 @@ import {
 
 export class ContentModel {
   public static fromRaw(data: ModelGraphData): ContentModel {
-    let model = Object.values(data.nodes).reduce(
-      (acc, node) => acc.addNode(node),
-      ContentModel.createEmpty()
-    )
-    model = Object.values(data.edges).reduce(
-      (acc, edge) => acc.addEdge(edge),
-      model
-    )
+    const model = new ContentModel(data.nodes, data.edges)
+    Object.values(model.edges).forEach((e) => model.checkEdgeNodes(e))
     return model
   }
 
@@ -143,9 +137,7 @@ export class ContentModel {
       attributes?: ModelAttributeSet
     }
   ): ContentModel {
-    // check source and target exist
-    this.getExistingNode(edge.source)
-    this.getExistingNode(edge.target)
+    this.checkEdgeNodes(edge)
     if (edge.id != null && this.containsEdge(edge.id)) {
       throw new Error(`Cannot add edge already in graph (${edge.id})`)
     }
@@ -156,6 +148,16 @@ export class ContentModel {
     }
     const edges = { ...this.edges, [newEdge.id]: newEdge }
     return new ContentModel(this.nodes, edges)
+  }
+
+  checkEdgeNodes(
+    edge: Omit<ModelEdge, 'id' | 'attributes'> & {
+      id?: string
+      attributes?: ModelAttributeSet
+    }
+  ): void {
+    this.getExistingNode(edge.source)
+    this.getExistingNode(edge.target)
   }
 
   getEdge(id: string): ModelEdge | undefined {

--- a/src/graph/data/jsonGraphExamples.ts
+++ b/src/graph/data/jsonGraphExamples.ts
@@ -2,7 +2,7 @@
 // Copyright 2014 Anthony Bargnesi, Anselmo DiFabio, William Hayes
 // https://github.com/jsongraph/jsongraph.rb
 
-import { JSONGraphData } from '../types'
+import { JSONGraphData, JSONGraphNode } from '../types'
 
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -25,7 +25,7 @@ import { JSONGraphData } from '../types'
 
 // Graphs from JSON Graph Spec to ensure compatibility
 
-export const smallGraph = {
+export const smallGraph: JSONGraphData = {
   graph: {
     id: 'car-manufacturer-relationships',
     type: 'car',
@@ -559,3 +559,25 @@ export const largeGraph = {
     },
   },
 } as JSONGraphData
+
+export const veryLargeGraph = {
+  graph: {
+    directed: true,
+    nodes: new Array(1000)
+      .fill(null)
+      .map((_, i) => ({
+        id: `id${i}`,
+        label: `label${i}`,
+        metadata: { type: 'Person' },
+      }))
+      .reduce<Record<string, JSONGraphNode>>((acc, next) => {
+        acc[next.id] = next
+        return acc
+      }, {}),
+
+    edges: new Array(1000).fill({
+      source: 'id1',
+      target: 'id2',
+    }),
+  },
+}

--- a/src/graph/fromJsonGraph.test.ts
+++ b/src/graph/fromJsonGraph.test.ts
@@ -1,4 +1,8 @@
-import { largeGraph, smallGraph } from './data/jsonGraphExamples'
+import {
+  largeGraph,
+  smallGraph,
+  veryLargeGraph,
+} from './data/jsonGraphExamples'
 import { fromJsonGraph } from './fromJsonGraph'
 import { JSONGraph, ModelNode } from './types'
 
@@ -100,4 +104,10 @@ it('ContentModel does not support hyperedges from graphs', () => {
       graph: hyperGraph,
     })
   ).toThrow()
+})
+
+it('loads very large graph', () => {
+  const contentModel = fromJsonGraph(veryLargeGraph)
+  expect(Object.keys(contentModel.nodes).length).toBe(1000)
+  expect(Object.keys(contentModel.edges).length).toBe(1000)
 })


### PR DESCRIPTION
Make fromJsonGraph() 10 times faster for graphs of 1000 or more nodes / edges. Construct the ContentModel using ContentModel.fromRaw() which now only creates the one final ContentModel.

Adds check to ContentModel.fromRaw() to check for valid edges.

The "loads very large graph" test case completes in 10ms, down from 220ms.