### PR TITLE
fix(ci): fix for release job in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,6 +202,14 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
       - name: npm 7
         run: npm i -g npm@7 --registry=https://registry.npmjs.org
+      - name: Restore dependencies
+        uses: actions/cache@v2
+        id: cache-dependencies
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:


### PR DESCRIPTION
Restores the npm cache incase this fixes the husky install issue with the build.
This might not work and we may need to move the script or exclude it somehow from the release.