### PR TITLE
fix(layout): fix to allow custom layout to run in built versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "scripts": {
     "clean": "shx rm -rf dist",
+    "commit": "cz",
     "build": "rollpkg build --tsconfig ./tsconfig.build.json",
     "watch": "rollpkg watch",
     "lint": "eslint './src/**/*.{ts,tsx}'",

--- a/src/graph/renderer/CytoscapeGraphLayoutAdapter.test.ts
+++ b/src/graph/renderer/CytoscapeGraphLayoutAdapter.test.ts
@@ -1,17 +1,22 @@
+import { CollectionArgument, NodeCollection } from 'cytoscape'
 import { GraphModel } from '../GraphModel'
 import {
-  CustomLayoutOptions,
+  CUSTOM_LAYOUT_NAME,
   CytoscapeGraphLayoutAdapter,
+  CytoscapeGraphLayoutAdapterManipulation,
+  CytoscapeGraphLayoutAdapterOptions,
+  register,
 } from './CytoscapeGraphLayoutAdapter'
-import { CollectionArgument, NodeCollection } from 'cytoscape'
 
 it('should not throw if cytoscape undefined', () => {
-  expect(CytoscapeGraphLayoutAdapter.register).not.toThrow()
+  const cyUseMock = jest.fn()
+  expect(() => register(cyUseMock)).not.toThrow()
 })
 
-it('should throw if no algorigthm defined', () => {
-  const adapter = new CytoscapeGraphLayoutAdapter(
-    {} as cytoscape.LayoutPositionOptions & CustomLayoutOptions
+it('should throw if no algorithm defined', () => {
+  const adapter = {} as CytoscapeGraphLayoutAdapterManipulation
+  CytoscapeGraphLayoutAdapter.bind(adapter)(
+    {} as CytoscapeGraphLayoutAdapterOptions
   )
   expect(() => {
     adapter.run()
@@ -21,12 +26,12 @@ it('should throw if no algorigthm defined', () => {
 it('should register with cytoscape', () => {
   const cyMock = jest.fn()
 
-  CytoscapeGraphLayoutAdapter.register(cyMock)
+  register(cyMock)
 
   expect(cyMock).toHaveBeenCalled()
   expect(cyMock).toHaveBeenCalledWith(
     'layout',
-    CytoscapeGraphLayoutAdapter.LAYOUT_NAME,
+    CUSTOM_LAYOUT_NAME,
     CytoscapeGraphLayoutAdapter
   )
 })
@@ -49,7 +54,8 @@ it('should run layout', () => {
         positions,
       } as unknown as NodeCollection),
   } as CollectionArgument
-  const adapter = new CytoscapeGraphLayoutAdapter({
+  const adapter = {} as CytoscapeGraphLayoutAdapterManipulation
+  CytoscapeGraphLayoutAdapter.bind(adapter)({
     model,
     algorithm,
     eles,

--- a/src/graph/renderer/CytoscapeGraphLayoutAdapter.ts
+++ b/src/graph/renderer/CytoscapeGraphLayoutAdapter.ts
@@ -1,62 +1,74 @@
-import { Ext, LayoutManipulation, LayoutPositionOptions, Core } from 'cytoscape'
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import {
+  Core,
+  Ext,
+  LayoutEventObject,
+  LayoutManipulation,
+  LayoutPositionOptions,
+} from 'cytoscape'
 import { GraphModel } from '../GraphModel'
 import { CustomGraphLayout } from '../types'
 
-export type CustomLayoutOptions = {
+export type CytoscapeGraphLayoutAdapterOptions = LayoutPositionOptions & {
+  name: string
   model: GraphModel
   algorithm: CustomGraphLayout
+  // Provided
+  cy: Core
 }
 
-export class CytoscapeGraphLayoutAdapter implements LayoutManipulation {
-  private readonly options: LayoutPositionOptions & CustomLayoutOptions
+export type CytoscapeGraphLayoutAdapterManipulation = LayoutManipulation & {
+  options: CytoscapeGraphLayoutAdapterOptions
+}
 
-  static readonly LAYOUT_NAME: string = 'custom'
+export const CUSTOM_LAYOUT_NAME = 'custom'
 
-  constructor(options: LayoutPositionOptions & CustomLayoutOptions) {
-    this.options = options
-  }
+export function CytoscapeGraphLayoutAdapter(
+  this: CytoscapeGraphLayoutAdapterManipulation,
+  options: CytoscapeGraphLayoutAdapterOptions
+): void {
+  this.options = Object.assign({}, options, { name: CUSTOM_LAYOUT_NAME })
 
-  static register: Ext = (cytoscape) => {
-    if (cytoscape == null) {
-      return
-    } // can't register if cytoscape unspecified
-    cytoscape(
-      'layout',
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      CytoscapeGraphLayoutAdapter.LAYOUT_NAME,
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      CytoscapeGraphLayoutAdapter
-    )
-  }
-
-  run(): this {
+  this.run = function (
+    this: CytoscapeGraphLayoutAdapterManipulation & LayoutEventObject
+  ) {
     if (this.options.algorithm == null) {
       throw new Error('No custom layout algorithm was specified')
     }
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    //@ts-ignore
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+
     const cy: Core = this.options.cy
     const boundingBox = { x1: 0, y1: 0, w: cy.width(), h: cy.height() }
     const nodePositions = this.options.algorithm.runLayout(this.options.model, {
       boundingBox,
     })
-    this.options.eles.nodes().positions((n) => {
+    this.options.eles.nodes().positions((n: { id: () => string | number }) => {
       return nodePositions[n.id()]
     })
     return this
   }
-
-  // alias for run()
-  start(): this {
+  this.start = function () {
     return this.run()
   }
 
   // called on continuous layouts to stop them before they finish
-  stop(): this {
+  this.stop = function () {
     this.options.algorithm.stopLayout()
     return this
   }
+}
+
+export const register: Ext = (cytoscape) => {
+  if (cytoscape == null) {
+    return
+  } // can't register if cytoscape unspecified
+  cytoscape(
+    'layout',
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    CUSTOM_LAYOUT_NAME,
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    CytoscapeGraphLayoutAdapter
+  )
 }

--- a/src/graph/renderer/CytoscapeRenderer.tsx
+++ b/src/graph/renderer/CytoscapeRenderer.tsx
@@ -43,8 +43,9 @@ import {
   PresetGraphLayout,
 } from '../types'
 import {
-  CustomLayoutOptions,
-  CytoscapeGraphLayoutAdapter,
+  CUSTOM_LAYOUT_NAME,
+  CytoscapeGraphLayoutAdapterOptions,
+  register,
 } from './CytoscapeGraphLayoutAdapter'
 import { useCyListener } from './useCyListener'
 
@@ -59,7 +60,7 @@ export function initializeCytoscape(
   cyuse: (module: cytoscape.Ext) => void
 ): void {
   try {
-    cyuse(CytoscapeGraphLayoutAdapter.register)
+    cyuse(register)
     cyuse(ccola)
   } catch {
     // Ignore multiple attempts to initialize
@@ -156,10 +157,10 @@ const Renderer: GraphRenderer<CyGraphRendererOptions>['render'] = ({
     grid,
     cola,
     custom: {
-      name: CytoscapeGraphLayoutAdapter.LAYOUT_NAME,
+      name: CUSTOM_LAYOUT_NAME,
       model: graphModel,
       algorithm: graphModel.getCurrentLayout().getLayout(),
-    } as CustomLayoutOptions & LayoutOptions,
+    } as CytoscapeGraphLayoutAdapterOptions & LayoutOptions,
   }
   const nodes = graphModel.nodes
   const edges = graphModel.edges
@@ -180,14 +181,14 @@ const Renderer: GraphRenderer<CyGraphRendererOptions>['render'] = ({
           typeof graphLayout === 'string'
             ? layouts[graphLayout]
             : ({
-                name: CytoscapeGraphLayoutAdapter.LAYOUT_NAME,
+                name: CUSTOM_LAYOUT_NAME,
                 model: graphModel,
                 algorithm: graphLayout,
-              } as CustomLayoutOptions)
+              } as CytoscapeGraphLayoutAdapterOptions)
         if (l == null) {
           throw new Error('Layout does not exist')
         }
-        cytoscape.layout(l as LayoutOptions).run()
+        cytoscape.layout(l).run()
       }
     },
     200


### PR DESCRIPTION
Uses an unusual function style to ensure complied as cytoscape expects.
Seems like a different in the output from the tsdx (v3 typescript) and
the rollpkg v4 typescript.

Added custom layout to example in order to test it works.

fix #41
