### PR TITLE
fix: add missing export for Rdf and Json

### DIFF
--- a/packages/all/src/index.ts
+++ b/packages/all/src/index.ts
@@ -5,6 +5,8 @@ export * from '@committed/components-graph-react'
 import { Json } from '@committed/graph-json'
 import { Rdf } from '@committed/graph-rdf'
 
+export { Json, Rdf }
+
 export const GraphBuilder = {
   fromJsonGraph: Json.buildGraph,
   fromRdfGraph: Rdf.buildGraph,

--- a/packages/react/src/graph/renderer/CytoscapeRenderer.tsx
+++ b/packages/react/src/graph/renderer/CytoscapeRenderer.tsx
@@ -74,18 +74,20 @@ function toSelector(prefix: 'node' | 'edge', id: string): string {
 }
 
 export interface CyGraphRendererOptions extends GraphRendererOptions {
-  renderOptions: Pick<
-    React.ComponentProps<typeof CytoscapeComponent>,
-    | 'zoom'
-    | 'minZoom'
-    | 'maxZoom'
-    | 'pan'
-    | 'zoomingEnabled'
-    | 'userZoomingEnabled'
-    | 'boxSelectionEnabled'
-    | 'autoungrabify'
-    | 'autounselectify'
-    | 'wheelSensitivity'
+  renderOptions?: Partial<
+    Pick<
+      React.ComponentProps<typeof CytoscapeComponent>,
+      | 'zoom'
+      | 'minZoom'
+      | 'maxZoom'
+      | 'pan'
+      | 'zoomingEnabled'
+      | 'userZoomingEnabled'
+      | 'boxSelectionEnabled'
+      | 'autoungrabify'
+      | 'autounselectify'
+      | 'wheelSensitivity'
+    >
   >
 }
 
@@ -307,7 +309,7 @@ const Renderer: GraphRenderer<CyGraphRendererOptions>['render'] = ({
     if (cytoscape == null) {
       return
     }
-    const zoomAmount = 1 + (options.renderOptions.wheelSensitivity ?? 1)
+    const zoomAmount = 1 + (options.renderOptions?.wheelSensitivity ?? 1)
     const position = { x: cytoscape.width() / 2, y: cytoscape.height() / 2 }
     commands.forEach((c) => {
       switch (c.type) {


### PR DESCRIPTION
They were used to create the GraphBuilder but not exported directly.
Improve types on render options.
