### PR TITLE
build: clarify build targets for the two build types

### DIFF
--- a/packages/config/esbuild/build.mjs
+++ b/packages/config/esbuild/build.mjs
@@ -10,18 +10,19 @@ const shared = {
   logLevel: 'info',
   minify: true,
   sourcemap: true,
-  target: ['esnext', 'node16'],
   plugins: [nodeExternalsPlugin()],
 }
 
 build({
   ...shared,
   format: 'esm',
+  target: ['esnext'],
   outfile: `${outFolder}/index.esm.js`,
 })
 
 build({
   ...shared,
   format: 'cjs',
+  target: ['node16'],
   outfile: `${outFolder}/index.cjs.js`,
 })


### PR DESCRIPTION
moves the correct target types up to the relevent build rather than having both in the common section

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Bug fix
[ ] Enhancement
[ ] Documentation
[ ] Deployment
[ ] Process (e.g. improve continuous integration)
[ ] Other, please explain:

**Which issue (if any) does this pull request address?**

Fixes

**What changes did you make?**

**Is there anything you'd like reviewers to focus on?**
